### PR TITLE
Fix NPE when Instructor was not yet claimed

### DIFF
--- a/src/main/java/ebr/Instructor.java
+++ b/src/main/java/ebr/Instructor.java
@@ -2,6 +2,7 @@ package ebr;
 
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 
@@ -35,5 +36,10 @@ public class Instructor extends RegisteredUser implements Serializable {
             this.lastName = lastName;
             this.email = email;
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return tempAuth != null ? tempAuth.hashCode() : name.hashCode();
     }
 }


### PR DESCRIPTION
This is a silly oversight! One-line fix for a NPE (hash attempt on null).